### PR TITLE
Fix lexer for "----" (<hr/>) case

### DIFF
--- a/markup/hr.go
+++ b/markup/hr.go
@@ -1,0 +1,34 @@
+package markup
+
+import (
+	"unicode"
+)
+
+// MatchesHorizontalLine checks if the string can be interpreted as suitable for rendering as <hr/>.
+//
+// The rule is: if there are more than 4 characters "-" in the string, then make it a horizontal line.
+// Otherwise it is a paragraph (<p>).
+func MatchesHorizontalLine(line string) bool {
+	counter := 0
+
+	// Check initially that the symbol is "-". If it is not a "-", it is most likely a space or another character.
+	// With unicode.IsLetter() we can separate spaces and characters.
+	for _, ch := range line {
+		if ch == '-' {
+			counter++
+			continue
+		}
+		// If we bump into any other character (letter) in the line, it is immediately an incorrect horizontal line.
+		// There is no point in counting further, we end the loop.
+		if unicode.IsLetter(ch) {
+			counter = 0
+			break
+		}
+	}
+
+	if counter >= 4 {
+		return true
+	}
+
+	return false
+}

--- a/markup/lexer.go
+++ b/markup/lexer.go
@@ -235,7 +235,7 @@ normalState:
 	case startsWith("<="):
 		addParagraphIfNeeded()
 		addLine(parseTransclusion(line, state.name))
-	case line[:4] == "----":
+	case MatchesHorizontalLine(line):
 		addParagraphIfNeeded()
 		*ast = append(*ast, Line{id: -1, contents: "<hr/>"})
 	case MatchesImg(line):

--- a/markup/lexer.go
+++ b/markup/lexer.go
@@ -235,7 +235,7 @@ normalState:
 	case startsWith("<="):
 		addParagraphIfNeeded()
 		addLine(parseTransclusion(line, state.name))
-	case line == "----":
+	case line[:4] == "----":
 		addParagraphIfNeeded()
 		*ast = append(*ast, Line{id: -1, contents: "<hr/>"})
 	case MatchesImg(line):


### PR DESCRIPTION
The point is that there may be another character in the string.
For example, a space or a line break.

Because we check the whole string, not the first 4 characters - we can ignore the variant where it can be `----\s` or `----\r\n` and make the wrong markup.

Alternatively: use `startsWith("----")`, but this is a bit more expensive operation.

![image](https://user-images.githubusercontent.com/44648612/110076786-079f3800-7dc0-11eb-90a1-78769b210d95.png)
