### PR TITLE
Panic fix (#44)

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,8 +85,16 @@ func handlerUpdateHeaderLinks(w http.ResponseWriter, rq *http.Request) {
 // Redirect to a random hypha.
 func handlerRandom(w http.ResponseWriter, rq *http.Request) {
 	log.Println(rq.URL)
-	var randomHyphaName string
-	i := rand.Intn(hyphae.Count())
+	var (
+		randomHyphaName string
+		amountOfHyphae  int = hyphae.Count()
+	)
+	if amountOfHyphae == 0 {
+		HttpErr(w, http.StatusNotFound, util.HomePage, "There are no hyphae",
+			"It is not possible to display a random hypha because the wiki does not contain any hyphae")
+		return
+	}
+	i := rand.Intn(amountOfHyphae)
 	for h := range hyphae.YieldExistingHyphae() {
 		if i == 0 {
 			randomHyphaName = h.Name


### PR DESCRIPTION
This fixes the bug when there are no hypha in the wiki and the user clicks the "random" button.

Since there are zero amount of pages, a number 0 is given to random, which causes a panic and resets the connection.

See: https://github.com/bouncepaw/mycorrhiza/issues/44