### PR TITLE
Add basic Nix packaging

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+# TODO: add shell support
+pkgs.callPackage ./release.nix { }
+

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, fetchFromGitHub, buildGoModule
+, git
+}:
+
+buildGoModule rec {
+  pname = "mycorrhiza";
+  version = "1.1.0";
+
+  src = ./.;
+
+  # That's for a nixpkgs release or something. Mind the hashes.
+  # src = fetchFromGitHub {
+  #   owner = "bouncepaw";
+  #   repo = "mycorrhiza";
+  #   rev = "v${version}";
+  #   sha256 = "0di4msrl44jcnhck11k0r7974cjnwdyw45b3hf0s3dbwx6ijdkdd";
+  #   fetchSubmodules = true;
+  # };
+
+  vendorSha256 = "0hxcbfh55avly9gvdysqgjzh66g7rdy2l0wmy9jnlq0skpa6j0jq"; 
+  
+  subPackages = [ "." ]; 
+
+  propagatedBuildInputs = [ git ];
+
+  meta = with lib; {
+    description = "Filesystem and git-based wiki engine written in Go using mycomarkup as its primary markup language";
+    homepage = "https://github.com/bouncepaw/mycorrhiza";
+    license = licenses.agpl3;
+    # maintainers = with maintainers; [ bouncepaw ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
A little treat for Nix/NixOS users.  Call ```nix-env -if .``` to install, figure it out to everyhing else.

Works without Git in the parent system (tested in the pure shell).

Got correct hashes for the recent 1.1.0 release (see the comment in release.nix, line 11 and onward), so it's pretty ready to be pushed into Nixpkgs. 
