### PR TITLE
Fix the link to the deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A wiki engine.
 [Main wiki](https://mycorrhiza.lesarbr.es)
 
 ## Building
-Also see [detailed instructions](https://mycorrhiza.lesarbr.es/hypha/deploy) on wiki.
+Also see [detailed instructions](https://mycorrhiza.lesarbr.es/hypha/guide/deployment) on wiki.
 ```sh
 git clone --recurse-submodules https://github.com/bouncepaw/mycorrhiza
 cd mycorrhiza


### PR DESCRIPTION
The old link lead to an empty page