### PR TITLE
Make toolbar actions lift the 'text changed' flag

### DIFF
--- a/static/editor.js
+++ b/static/editor.js
@@ -1,20 +1,20 @@
 (function () {
-	let changed = false;
+	window.hyphaChanged = false;
 	let textarea = document.querySelector('.edit-form__textarea');
 	let form = document.querySelector('.edit-form');
 
 	let warnBeforeClosing = function (ev) {
-		if (!changed) return;
+		if (!window.hyphaChanged) return;
 		ev.preventDefault();
 		return ev.returnValue = 'Are you sure you want to exit? You have unsaved changes.';
 	};
 
 	textarea.addEventListener('input', function () {
-		changed = true;
+		window.hyphaChanged = true;
 	});
 
 	form.addEventListener('submit', function () {
-		changed = false;
+		window.hyphaChanged = false;
 	});
 
 	window.addEventListener('beforeunload', warnBeforeClosing);

--- a/static/toolbar.js
+++ b/static/toolbar.js
@@ -13,6 +13,7 @@ function getSelectedText(el = editTextarea) {
 
 function textInserter(text, cursorPosition = null, el = editTextarea) {
     return function() {
+        window.hyphaChanged = true;
         const [start, end] = [el.selectionStart, el.selectionEnd]
         el.setRangeText(text, start, end, 'select')
         el.focus()
@@ -26,6 +27,7 @@ function textInserter(text, cursorPosition = null, el = editTextarea) {
 
 function selectionWrapper(cursorPosition, prefix, postfix = null, el = editTextarea) {
     return function() {
+        window.hyphaChanged = true;
         const [start, end] = [el.selectionStart, el.selectionEnd]
         if (postfix == null) {
             postfix = prefix


### PR DESCRIPTION
Improves `text not saved` warning feature, adds two global variables for other modules (`hyphaChanged`, `hyphaOriginal`).