### PR TITLE
Fix ghost siblings and orphaned subhyphae view

### DIFF
--- a/tree/view.qtpl
+++ b/tree/view.qtpl
@@ -36,7 +36,7 @@ pseudographics:
 
 {% func siblingHTML(s *sibling) %}
 <li class="sibling-hyphae__entry">
-	<a class="sibling-hyphae__link" href="/hypha/{%s s.name %}">
+	<a class="sibling-hyphae__link {% if !s.exists %}wikilink_new{% endif %}" href="/hypha/{%s s.name %}">
 		{%s util.BeautifulName(path.Base(s.name)) %}
 		<span class="sibling-hyphae__count">
 		{% if s.directSubhyphaeCount > 0 %}

--- a/tree/view.qtpl
+++ b/tree/view.qtpl
@@ -20,7 +20,7 @@ pseudographics:
 	})
 %}
 <li class="subhyphae__entry">
-	<a class="subhyphae__link" href="/hypha/{%s c.name %}">
+	<a class="subhyphae__link {% if !c.exists %}wikilink_new{% endif %}" href="/hypha/{%s c.name %}">
 		{%s util.BeautifulName(path.Base(c.name)) %}
 	</a>
 {% if len(c.children) > 0 %}

--- a/tree/view.qtpl.go
+++ b/tree/view.qtpl.go
@@ -156,7 +156,15 @@ func streamsiblingHTML(qw422016 *qt422016.Writer, s *sibling) {
 //line tree/view.qtpl:37
 	qw422016.N().S(`
 <li class="sibling-hyphae__entry">
-	<a class="sibling-hyphae__link" href="/hypha/`)
+	<a class="sibling-hyphae__link `)
+//line tree/view.qtpl:39
+	if !s.exists {
+//line tree/view.qtpl:39
+		qw422016.N().S(`wikilink_new`)
+//line tree/view.qtpl:39
+	}
+//line tree/view.qtpl:39
+	qw422016.N().S(`" href="/hypha/`)
 //line tree/view.qtpl:39
 	qw422016.E().S(s.name)
 //line tree/view.qtpl:39

--- a/tree/view.qtpl.go
+++ b/tree/view.qtpl.go
@@ -82,7 +82,15 @@ func streamchildHTML(qw422016 *qt422016.Writer, c *child) {
 //line tree/view.qtpl:21
 	qw422016.N().S(`
 <li class="subhyphae__entry">
-	<a class="subhyphae__link" href="/hypha/`)
+	<a class="subhyphae__link `)
+//line tree/view.qtpl:23
+	if !c.exists {
+//line tree/view.qtpl:23
+		qw422016.N().S(`wikilink_new`)
+//line tree/view.qtpl:23
+	}
+//line tree/view.qtpl:23
+	qw422016.N().S(`" href="/hypha/`)
 //line tree/view.qtpl:23
 	qw422016.E().S(c.name)
 //line tree/view.qtpl:23


### PR DESCRIPTION
Previously you would have missing subhyphae in a tree view and sibling lists, as Mycorrhiza required transitional subhyphae to exist. 

Now it is not the issue, as it automatically adds missing transitional subhyphae, marking them as missing.