### PR TITLE
Fix go.mod to fully enumerate dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 require (
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20211109184856-51b60fd695b3 // indirect
 )
 


### PR DESCRIPTION
This allows build infrastructure which uses go mod vendor with go 1.17
to work (i.e. nixos).

I generated this change by running go mod vendor, then deleting the vendor folder.