### PR TITLE
Add data-rrh-cat attributes for hypha categories

### DIFF
--- a/auth/web.go
+++ b/auth/web.go
@@ -39,7 +39,7 @@ func handlerUserList(w http.ResponseWriter, rq *http.Request) {
 	lc := l18n.FromRequest(rq)
 	w.Header().Set("Content-Type", mime.TypeByExtension(".html"))
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(viewutil.Base(viewutil.MetaFrom(w, rq), lc.Get("ui.users_title"), UserList(lc))))
+	w.Write([]byte(viewutil.Base(viewutil.MetaFrom(w, rq), lc.Get("ui.users_title"), UserList(lc), []string{})))
 }
 
 func handlerLock(w http.ResponseWriter, rq *http.Request) {
@@ -57,6 +57,7 @@ func handlerRegister(w http.ResponseWriter, rq *http.Request) {
 				viewutil.MetaFrom(w, rq),
 				lc.Get("auth.register_title"),
 				Register(rq),
+				[]string{},
 			),
 		)
 		return
@@ -81,6 +82,7 @@ func handlerRegister(w http.ResponseWriter, rq *http.Request) {
 					err.Error(),
 					lc.Get("auth.try_again"),
 				),
+				[]string{},
 			),
 		)
 		return
@@ -111,7 +113,7 @@ func handlerLogout(w http.ResponseWriter, rq *http.Request) {
 		}
 		_, _ = io.WriteString(
 			w,
-			viewutil.Base(viewutil.MetaFrom(w, rq), lc.Get("auth.logout_title"), Logout(can, lc)),
+			viewutil.Base(viewutil.MetaFrom(w, rq), lc.Get("auth.logout_title"), Logout(can, lc), []string{}),
 		)
 	} else if rq.Method == http.MethodPost {
 		user.LogoutFromRequest(w, rq)
@@ -131,6 +133,7 @@ func handlerLogin(w http.ResponseWriter, rq *http.Request) {
 				viewutil.MetaFrom(w, rq),
 				lc.Get("auth.login_title"),
 				Login(lc),
+				[]string{},
 			),
 		)
 	} else if rq.Method == http.MethodPost {
@@ -142,7 +145,7 @@ func handlerLogin(w http.ResponseWriter, rq *http.Request) {
 		if err != nil {
 			w.Header().Set("Content-Type", "text/html;charset=utf-8")
 			w.WriteHeader(http.StatusInternalServerError)
-			_, _ = io.WriteString(w, viewutil.Base(viewutil.MetaFrom(w, rq), err.Error(), LoginError(err.Error(), lc)))
+			_, _ = io.WriteString(w, viewutil.Base(viewutil.MetaFrom(w, rq), err.Error(), LoginError(err.Error(), lc), []string{}))
 			return
 		}
 		http.Redirect(w, rq, "/", http.StatusSeeOther)
@@ -189,6 +192,7 @@ func handlerTelegramLogin(w http.ResponseWriter, rq *http.Request) {
 					err.Error(),
 					lc.Get("auth.go_login"),
 				),
+				[]string{},
 			),
 		)
 		return
@@ -209,6 +213,7 @@ func handlerTelegramLogin(w http.ResponseWriter, rq *http.Request) {
 					err.Error(),
 					lc.Get("auth.go_login"),
 				),
+				[]string{},
 			),
 		)
 		return

--- a/auth/web.go
+++ b/auth/web.go
@@ -39,7 +39,7 @@ func handlerUserList(w http.ResponseWriter, rq *http.Request) {
 	lc := l18n.FromRequest(rq)
 	w.Header().Set("Content-Type", mime.TypeByExtension(".html"))
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(viewutil.Base(viewutil.MetaFrom(w, rq), lc.Get("ui.users_title"), UserList(lc), []string{})))
+	w.Write([]byte(viewutil.Base(viewutil.MetaFrom(w, rq), lc.Get("ui.users_title"), UserList(lc), map[string]string{})))
 }
 
 func handlerLock(w http.ResponseWriter, rq *http.Request) {
@@ -57,7 +57,7 @@ func handlerRegister(w http.ResponseWriter, rq *http.Request) {
 				viewutil.MetaFrom(w, rq),
 				lc.Get("auth.register_title"),
 				Register(rq),
-				[]string{},
+				map[string]string{},
 			),
 		)
 		return
@@ -82,7 +82,7 @@ func handlerRegister(w http.ResponseWriter, rq *http.Request) {
 					err.Error(),
 					lc.Get("auth.try_again"),
 				),
-				[]string{},
+				map[string]string{},
 			),
 		)
 		return
@@ -113,7 +113,7 @@ func handlerLogout(w http.ResponseWriter, rq *http.Request) {
 		}
 		_, _ = io.WriteString(
 			w,
-			viewutil.Base(viewutil.MetaFrom(w, rq), lc.Get("auth.logout_title"), Logout(can, lc), []string{}),
+			viewutil.Base(viewutil.MetaFrom(w, rq), lc.Get("auth.logout_title"), Logout(can, lc), map[string]string{}),
 		)
 	} else if rq.Method == http.MethodPost {
 		user.LogoutFromRequest(w, rq)
@@ -133,7 +133,7 @@ func handlerLogin(w http.ResponseWriter, rq *http.Request) {
 				viewutil.MetaFrom(w, rq),
 				lc.Get("auth.login_title"),
 				Login(lc),
-				[]string{},
+				map[string]string{},
 			),
 		)
 	} else if rq.Method == http.MethodPost {
@@ -145,7 +145,7 @@ func handlerLogin(w http.ResponseWriter, rq *http.Request) {
 		if err != nil {
 			w.Header().Set("Content-Type", "text/html;charset=utf-8")
 			w.WriteHeader(http.StatusInternalServerError)
-			_, _ = io.WriteString(w, viewutil.Base(viewutil.MetaFrom(w, rq), err.Error(), LoginError(err.Error(), lc), []string{}))
+			_, _ = io.WriteString(w, viewutil.Base(viewutil.MetaFrom(w, rq), err.Error(), LoginError(err.Error(), lc), map[string]string{}))
 			return
 		}
 		http.Redirect(w, rq, "/", http.StatusSeeOther)
@@ -192,7 +192,7 @@ func handlerTelegramLogin(w http.ResponseWriter, rq *http.Request) {
 					err.Error(),
 					lc.Get("auth.go_login"),
 				),
-				[]string{},
+				map[string]string{},
 			),
 		)
 		return
@@ -213,7 +213,7 @@ func handlerTelegramLogin(w http.ResponseWriter, rq *http.Request) {
 					err.Error(),
 					lc.Get("auth.go_login"),
 				),
-				[]string{},
+				map[string]string{},
 			),
 		)
 		return

--- a/categories/categories.go
+++ b/categories/categories.go
@@ -33,8 +33,8 @@ func listOfCategories() (categoryList []string) {
 	return categoryList
 }
 
-// categoriesWithHypha returns what categories have the given hypha. The hypha name must be canonical.
-func categoriesWithHypha(hyphaName string) (categoryList []string) {
+// CategoriesWithHypha returns what categories have the given hypha. The hypha name must be canonical.
+func CategoriesWithHypha(hyphaName string) (categoryList []string) {
 	mutex.RLock()
 	defer mutex.RUnlock()
 	if node, ok := hyphaToCategories[hyphaName]; ok {

--- a/categories/views.go
+++ b/categories/views.go
@@ -52,7 +52,7 @@ func CategoryCard(meta viewutil.Meta, hyphaName string) string {
 	var buf strings.Builder
 	err := viewCardChain.Get(meta).ExecuteTemplate(&buf, "category card", cardData{
 		HyphaName:               hyphaName,
-		Categories:              categoriesWithHypha(hyphaName),
+		Categories:              CategoriesWithHypha(hyphaName),
 		GivenPermissionToModify: meta.U.CanProceed("add-to-category"),
 	})
 	if err != nil {

--- a/misc/handlers.go
+++ b/misc/handlers.go
@@ -125,6 +125,7 @@ func handlerAbout(w http.ResponseWriter, rq *http.Request) {
 		viewutil.MetaFrom(w, rq),
 		title,
 		AboutHTML(lc),
+		[]string{},
 	))
 	if err != nil {
 		log.Println(err)

--- a/misc/handlers.go
+++ b/misc/handlers.go
@@ -125,7 +125,7 @@ func handlerAbout(w http.ResponseWriter, rq *http.Request) {
 		viewutil.MetaFrom(w, rq),
 		title,
 		AboutHTML(lc),
-		[]string{},
+		map[string]string{},
 	))
 	if err != nil {
 		log.Println(err)

--- a/viewutil/base.html
+++ b/viewutil/base.html
@@ -15,7 +15,7 @@
 	<script src="/static/shortcuts.js"></script>
 	{{range .HeadElements}}{{.}}{{end}}
 </head>
-<body data-rrh-addr="{{if .Addr}}{{.Addr}}{{else}}{{.Meta.Addr}}{{end}}">
+<body data-rrh-addr="{{if .Addr}}{{.Addr}}{{else}}{{.Meta.Addr}}{{end}}"{{range .ExtraData}} data-rrh-{{.}}=""{{end}}>
 <header>
 	<nav class="main-width top-bar">
 		<ul class="top-bar__wrapper">

--- a/viewutil/base.html
+++ b/viewutil/base.html
@@ -15,7 +15,7 @@
 	<script src="/static/shortcuts.js"></script>
 	{{range .HeadElements}}{{.}}{{end}}
 </head>
-<body data-rrh-addr="{{if .Addr}}{{.Addr}}{{else}}{{.Meta.Addr}}{{end}}"{{range .BodyAttributes}} data-rrh-{{.}}=""{{end}}>
+<body data-rrh-addr="{{if .Addr}}{{.Addr}}{{else}}{{.Meta.Addr}}{{end}}"{{range $key, $value := .BodyAttributes}} data-rrh-{{$key}}="{{$value}}"{{end}}>
 <header>
 	<nav class="main-width top-bar">
 		<ul class="top-bar__wrapper">

--- a/viewutil/base.html
+++ b/viewutil/base.html
@@ -15,7 +15,7 @@
 	<script src="/static/shortcuts.js"></script>
 	{{range .HeadElements}}{{.}}{{end}}
 </head>
-<body data-rrh-addr="{{if .Addr}}{{.Addr}}{{else}}{{.Meta.Addr}}{{end}}"{{range .ExtraData}} data-rrh-{{.}}=""{{end}}>
+<body data-rrh-addr="{{if .Addr}}{{.Addr}}{{else}}{{.Meta.Addr}}{{end}}"{{range .BodyAttributes}} data-rrh-{{.}}=""{{end}}>
 <header>
 	<nav class="main-width top-bar">
 		<ul class="top-bar__wrapper">

--- a/viewutil/err.go
+++ b/viewutil/err.go
@@ -22,7 +22,7 @@ func HttpErr(meta Meta, status int, name, errMsg string) {
 				name,
 				meta.Lc.Get("ui.error_go_back"),
 			),
-			[]string{},
+			map[string]string{},
 		),
 	)
 }

--- a/viewutil/err.go
+++ b/viewutil/err.go
@@ -22,6 +22,7 @@ func HttpErr(meta Meta, status int, name, errMsg string) {
 				name,
 				meta.Lc.Get("ui.error_go_back"),
 			),
+			[]string{},
 		),
 	)
 }

--- a/viewutil/viewutil.go
+++ b/viewutil/viewutil.go
@@ -91,14 +91,14 @@ func localizedBaseWithWeirdBody(meta Meta) *template.Template {
 }
 
 type BaseData struct {
-	Meta          Meta
-	HeadElements  []string
-	HeaderLinks   []HeaderLink
-	CommonScripts []string
-	Addr          string
-	Title         string // TODO: remove
-	Body          string // TODO: remove
-	ExtraData    []string
+	Meta           Meta
+	HeadElements   []string
+	HeaderLinks    []HeaderLink
+	CommonScripts  []string
+	Addr           string
+	Title          string // TODO: remove
+	Body           string // TODO: remove
+	BodyAttributes []string
 }
 
 func (bd *BaseData) withBaseValues(meta Meta, headerLinks []HeaderLink, commonScripts []string) {
@@ -114,13 +114,13 @@ func Base(meta Meta, title, body string, extraData []string, headElements ...str
 	meta.W = &w
 	t := localizedBaseWithWeirdBody(meta)
 	err := t.ExecuteTemplate(&w, "page", BaseData{
-		Meta:          meta,
-		Title:         title,
-		HeadElements:  headElements,
-		HeaderLinks:   HeaderLinks,
-		CommonScripts: cfg.CommonScripts,
-		Body:          body,
-		ExtraData:     extraData,
+		Meta:           meta,
+		Title:          title,
+		HeadElements:   headElements,
+		HeaderLinks:    HeaderLinks,
+		CommonScripts:  cfg.CommonScripts,
+		Body:           body,
+		BodyAttributes: extraData,
 	})
 	if err != nil {
 		log.Println(err)

--- a/viewutil/viewutil.go
+++ b/viewutil/viewutil.go
@@ -98,6 +98,7 @@ type BaseData struct {
 	Addr          string
 	Title         string // TODO: remove
 	Body          string // TODO: remove
+	ExtraData    []string
 }
 
 func (bd *BaseData) withBaseValues(meta Meta, headerLinks []HeaderLink, commonScripts []string) {
@@ -108,7 +109,7 @@ func (bd *BaseData) withBaseValues(meta Meta, headerLinks []HeaderLink, commonSc
 
 // Base is a temporary wrapper around BaseEn and BaseRu, meant to facilitate the migration from qtpl.
 // TODO: get rid of this
-func Base(meta Meta, title, body string, headElements ...string) string {
+func Base(meta Meta, title, body string, extraData []string, headElements ...string) string {
 	var w strings.Builder
 	meta.W = &w
 	t := localizedBaseWithWeirdBody(meta)
@@ -119,6 +120,7 @@ func Base(meta Meta, title, body string, headElements ...string) string {
 		HeaderLinks:   HeaderLinks,
 		CommonScripts: cfg.CommonScripts,
 		Body:          body,
+		ExtraData:     extraData,
 	})
 	if err != nil {
 		log.Println(err)

--- a/viewutil/viewutil.go
+++ b/viewutil/viewutil.go
@@ -98,7 +98,7 @@ type BaseData struct {
 	Addr           string
 	Title          string // TODO: remove
 	Body           string // TODO: remove
-	BodyAttributes []string
+	BodyAttributes map[string]string
 }
 
 func (bd *BaseData) withBaseValues(meta Meta, headerLinks []HeaderLink, commonScripts []string) {
@@ -109,7 +109,7 @@ func (bd *BaseData) withBaseValues(meta Meta, headerLinks []HeaderLink, commonSc
 
 // Base is a temporary wrapper around BaseEn and BaseRu, meant to facilitate the migration from qtpl.
 // TODO: get rid of this
-func Base(meta Meta, title, body string, extraData []string, headElements ...string) string {
+func Base(meta Meta, title, body string, bodyAttributes map[string]string, headElements ...string) string {
 	var w strings.Builder
 	meta.W = &w
 	t := localizedBaseWithWeirdBody(meta)
@@ -120,7 +120,7 @@ func Base(meta Meta, title, body string, extraData []string, headElements ...str
 		HeaderLinks:    HeaderLinks,
 		CommonScripts:  cfg.CommonScripts,
 		Body:           body,
-		BodyAttributes: extraData,
+		BodyAttributes: bodyAttributes,
 	})
 	if err != nil {
 		log.Println(err)

--- a/web/mutators.go
+++ b/web/mutators.go
@@ -49,7 +49,9 @@ func handlerRemoveMedia(w http.ResponseWriter, rq *http.Request) {
 			viewutil.Base(
 				meta,
 				fmt.Sprintf(lc.Get("ui.ask_remove_media"), util.BeautifulName(h.CanonicalName())),
-				hypview.RemoveMediaAsk(rq, h.CanonicalName())))
+				hypview.RemoveMediaAsk(rq, h.CanonicalName()),
+				[]string{},
+			    ))
 		return
 	}
 	switch h := h.(type) {
@@ -175,7 +177,8 @@ func handlerEdit(w http.ResponseWriter, rq *http.Request) {
 		viewutil.Base(
 			meta,
 			fmt.Sprintf(lc.Get("edit.title"), util.BeautifulName(hyphaName)),
-			hypview.Editor(rq, hyphaName, textAreaFill, warning)))
+			hypview.Editor(rq, hyphaName, textAreaFill, warning),
+			[]string{}))
 }
 
 // handlerUploadText uploads a new text part for the hypha.
@@ -213,7 +216,9 @@ func handlerUploadText(w http.ResponseWriter, rq *http.Request) {
 					textData,
 					message,
 					"",
-					mycomarkup.BlocksToHTML(ctx, mycomarkup.BlockTree(ctx)))))
+					mycomarkup.BlocksToHTML(ctx, mycomarkup.BlockTree(ctx))),
+				[]string{},
+				    ))
 	} else {
 		http.Redirect(w, rq, "/hypha/"+hyphaName, http.StatusSeeOther)
 	}

--- a/web/mutators.go
+++ b/web/mutators.go
@@ -51,7 +51,7 @@ func handlerRemoveMedia(w http.ResponseWriter, rq *http.Request) {
 				fmt.Sprintf(lc.Get("ui.ask_remove_media"), util.BeautifulName(h.CanonicalName())),
 				hypview.RemoveMediaAsk(rq, h.CanonicalName()),
 				map[string]string{},
-			    ))
+			))
 		return
 	}
 	switch h := h.(type) {
@@ -218,7 +218,7 @@ func handlerUploadText(w http.ResponseWriter, rq *http.Request) {
 					"",
 					mycomarkup.BlocksToHTML(ctx, mycomarkup.BlockTree(ctx))),
 				map[string]string{},
-				    ))
+			))
 	} else {
 		http.Redirect(w, rq, "/hypha/"+hyphaName, http.StatusSeeOther)
 	}

--- a/web/mutators.go
+++ b/web/mutators.go
@@ -50,7 +50,7 @@ func handlerRemoveMedia(w http.ResponseWriter, rq *http.Request) {
 				meta,
 				fmt.Sprintf(lc.Get("ui.ask_remove_media"), util.BeautifulName(h.CanonicalName())),
 				hypview.RemoveMediaAsk(rq, h.CanonicalName()),
-				[]string{},
+				map[string]string{},
 			    ))
 		return
 	}
@@ -178,7 +178,7 @@ func handlerEdit(w http.ResponseWriter, rq *http.Request) {
 			meta,
 			fmt.Sprintf(lc.Get("edit.title"), util.BeautifulName(hyphaName)),
 			hypview.Editor(rq, hyphaName, textAreaFill, warning),
-			[]string{}))
+			map[string]string{}))
 }
 
 // handlerUploadText uploads a new text part for the hypha.
@@ -217,7 +217,7 @@ func handlerUploadText(w http.ResponseWriter, rq *http.Request) {
 					message,
 					"",
 					mycomarkup.BlocksToHTML(ctx, mycomarkup.BlockTree(ctx))),
-				[]string{},
+				map[string]string{},
 				    ))
 	} else {
 		http.Redirect(w, rq, "/hypha/"+hyphaName, http.StatusSeeOther)

--- a/web/readers.go
+++ b/web/readers.go
@@ -7,6 +7,7 @@ import (
 	views2 "github.com/bouncepaw/mycorrhiza/hypview"
 	"github.com/bouncepaw/mycorrhiza/mycoopts"
 	"github.com/bouncepaw/mycorrhiza/viewutil"
+	"github.com/bouncepaw/mycorrhiza/categories"
 	"io"
 	"log"
 	"net/http"
@@ -210,13 +211,17 @@ func handlerHypha(w http.ResponseWriter, rq *http.Request) {
 			contents = mycoopts.Media(h, lc) + contents
 		}
 
+		cats := []string{}
+		for _, category := range categories.CategoriesWithHypha(h.CanonicalName()) {
+		    cats = append(cats, "cat-" + category)
+		}
 
 		util.HTTP200Page(w,
 			viewutil.Base(
 				viewutil.MetaFrom(w, rq),
 				util.BeautifulName(hyphaName),
 				views2.Hypha(viewutil.MetaFrom(w, rq), h, contents),
-				[]string{},
+				cats,
 				openGraph))
 	}
 }

--- a/web/readers.go
+++ b/web/readers.go
@@ -3,11 +3,11 @@ package web
 import (
 	"fmt"
 	"github.com/bouncepaw/mycomarkup/v5"
+	"github.com/bouncepaw/mycorrhiza/categories"
 	"github.com/bouncepaw/mycorrhiza/files"
 	views2 "github.com/bouncepaw/mycorrhiza/hypview"
 	"github.com/bouncepaw/mycorrhiza/mycoopts"
 	"github.com/bouncepaw/mycorrhiza/viewutil"
-	"github.com/bouncepaw/mycorrhiza/categories"
 	"io"
 	"log"
 	"net/http"
@@ -51,7 +51,7 @@ func handlerMedia(w http.ResponseWriter, rq *http.Request) {
 			lc.Get("ui.media_title", &l18n.Replacements{"name": util.BeautifulName(hyphaName)}),
 			views2.MediaMenu(rq, h, u),
 			map[string]string{},
-		    ))
+		))
 }
 
 // handlerRevisionText sends Mycomarkup text of the hypha at the given revision. See also: handlerRevision, handlerText.
@@ -211,14 +211,14 @@ func handlerHypha(w http.ResponseWriter, rq *http.Request) {
 			contents = mycoopts.Media(h, lc) + contents
 		}
 
-                category_list := ":" + strings.Join(categories.CategoriesWithHypha(h.CanonicalName()), ":") + ":"
+		category_list := ":" + strings.Join(categories.CategoriesWithHypha(h.CanonicalName()), ":") + ":"
 
 		util.HTTP200Page(w,
 			viewutil.Base(
 				viewutil.MetaFrom(w, rq),
 				util.BeautifulName(hyphaName),
 				views2.Hypha(viewutil.MetaFrom(w, rq), h, contents),
-                                map[string]string{"cats": category_list},
+				map[string]string{"cats": category_list},
 				openGraph))
 	}
 }

--- a/web/readers.go
+++ b/web/readers.go
@@ -48,7 +48,9 @@ func handlerMedia(w http.ResponseWriter, rq *http.Request) {
 		viewutil.Base(
 			viewutil.MetaFrom(w, rq),
 			lc.Get("ui.media_title", &l18n.Replacements{"name": util.BeautifulName(hyphaName)}),
-			views2.MediaMenu(rq, h, u)))
+			views2.MediaMenu(rq, h, u),
+			[]string{},
+		    ))
 }
 
 // handlerRevisionText sends Mycomarkup text of the hypha at the given revision. See also: handlerRevision, handlerText.
@@ -141,6 +143,7 @@ func handlerRevision(w http.ResponseWriter, rq *http.Request) {
 			viewutil.MetaFrom(w, rq),
 			lc.Get("ui.revision_title", &l18n.Replacements{"name": util.BeautifulName(hyphaName), "rev": revHash}),
 			page,
+			[]string{},
 		),
 	)
 }
@@ -191,6 +194,7 @@ func handlerHypha(w http.ResponseWriter, rq *http.Request) {
 				viewutil.MetaFrom(w, rq),
 				util.BeautifulName(hyphaName),
 				views2.Hypha(viewutil.MetaFrom(w, rq), h, contents),
+				[]string{},
 				openGraph))
 	case hyphae.ExistingHypha:
 		fileContentsT, errT := os.ReadFile(h.TextFilePath())
@@ -206,11 +210,13 @@ func handlerHypha(w http.ResponseWriter, rq *http.Request) {
 			contents = mycoopts.Media(h, lc) + contents
 		}
 
+
 		util.HTTP200Page(w,
 			viewutil.Base(
 				viewutil.MetaFrom(w, rq),
 				util.BeautifulName(hyphaName),
 				views2.Hypha(viewutil.MetaFrom(w, rq), h, contents),
+				[]string{},
 				openGraph))
 	}
 }

--- a/web/readers.go
+++ b/web/readers.go
@@ -50,7 +50,7 @@ func handlerMedia(w http.ResponseWriter, rq *http.Request) {
 			viewutil.MetaFrom(w, rq),
 			lc.Get("ui.media_title", &l18n.Replacements{"name": util.BeautifulName(hyphaName)}),
 			views2.MediaMenu(rq, h, u),
-			[]string{},
+			map[string]string{},
 		    ))
 }
 
@@ -144,7 +144,7 @@ func handlerRevision(w http.ResponseWriter, rq *http.Request) {
 			viewutil.MetaFrom(w, rq),
 			lc.Get("ui.revision_title", &l18n.Replacements{"name": util.BeautifulName(hyphaName), "rev": revHash}),
 			page,
-			[]string{},
+			map[string]string{},
 		),
 	)
 }
@@ -195,7 +195,7 @@ func handlerHypha(w http.ResponseWriter, rq *http.Request) {
 				viewutil.MetaFrom(w, rq),
 				util.BeautifulName(hyphaName),
 				views2.Hypha(viewutil.MetaFrom(w, rq), h, contents),
-				[]string{},
+				map[string]string{},
 				openGraph))
 	case hyphae.ExistingHypha:
 		fileContentsT, errT := os.ReadFile(h.TextFilePath())
@@ -211,17 +211,14 @@ func handlerHypha(w http.ResponseWriter, rq *http.Request) {
 			contents = mycoopts.Media(h, lc) + contents
 		}
 
-		cats := []string{}
-		for _, category := range categories.CategoriesWithHypha(h.CanonicalName()) {
-		    cats = append(cats, "cat-" + category)
-		}
+                category_list := ":" + strings.Join(categories.CategoriesWithHypha(h.CanonicalName()), ":") + ":"
 
 		util.HTTP200Page(w,
 			viewutil.Base(
 				viewutil.MetaFrom(w, rq),
 				util.BeautifulName(hyphaName),
 				views2.Hypha(viewutil.MetaFrom(w, rq), h, contents),
-				cats,
+                                map[string]string{"cats": category_list},
 				openGraph))
 	}
 }


### PR DESCRIPTION
Closes #157 

I wasn't sure the best way to go about this. I wasn't a fan of adding a `categories` parameter to `viewutil.Base` since that view is used by routes that aren't hyphae (and so don't have categories). So I added a more generic `extraData` parameter that renders as extra `data-rrh-*` attributes on the body tag, in case adding extra attributes is useful for something in the future.