### PR TITLE
Add a version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,15 @@ PREFIX=/usr/local
 BINDIR=$(PREFIX)/bin
 MANDIR=$(PREFIX)/share/man
 GO=go
+TAGGED_RELEASE=$(shell git describe --tags --abbrev=0)
+COMMIT_HASH=$(shell echo -n $(shell git rev-parse --short HEAD) && git diff-index --quiet HEAD -- || echo -n '-dirty')
+LDFLAGS=-X "github.com/bouncepaw/mycorrhiza/version.TaggedRelease=$(TAGGED_RELEASE)" -X "github.com/bouncepaw/mycorrhiza/version.CommitHash=$(COMMIT_HASH)"
 
 all: mycorrhiza
 
 mycorrhiza:
 	$(GO) generate $(GOFLAGS)
-	CGO_ENABLED=0 $(GO) build $(GOFLAGS) -o mycorrhiza .
+	CGO_ENABLED=0 $(GO) build -ldflags="$(LDFLAGS)" $(GOFLAGS) -o mycorrhiza .
 
 install:
 	mkdir -m755 -p $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR)/man1

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PREFIX=/usr/local
 BINDIR=$(PREFIX)/bin
 MANDIR=$(PREFIX)/share/man
 GO=go
-TAGGED_RELEASE=$(shell git describe --tags --abbrev=0)
+TAGGED_RELEASE!=git describe --tags --abbrev=0
 LDFLAGS=-X "github.com/bouncepaw/mycorrhiza/version.taggedRelease=$(TAGGED_RELEASE)"
 
 all: mycorrhiza

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ BINDIR=$(PREFIX)/bin
 MANDIR=$(PREFIX)/share/man
 GO=go
 TAGGED_RELEASE=$(shell git describe --tags --abbrev=0)
-COMMIT_HASH=$(shell echo -n $(shell git rev-parse --short HEAD) && git diff-index --quiet HEAD -- || echo -n '-dirty')
-LDFLAGS=-X "github.com/bouncepaw/mycorrhiza/version.TaggedRelease=$(TAGGED_RELEASE)" -X "github.com/bouncepaw/mycorrhiza/version.CommitHash=$(COMMIT_HASH)"
+LDFLAGS=-X "github.com/bouncepaw/mycorrhiza/version.taggedRelease=$(TAGGED_RELEASE)"
 
 all: mycorrhiza
 

--- a/flag.go
+++ b/flag.go
@@ -36,7 +36,7 @@ func parseCliArgs() {
 
 	flag.StringVar(&cfg.ListenAddr, "listen-addr", "", "Address to listen on. For example, 127.0.0.1:1737 or /run/mycorrhiza.sock.")
 	flag.StringVar(&createAdminName, "create-admin", "", "Create a new admin. The password will be prompted in the terminal.")
-	flag.BoolVar(&versionFlag, "version", false, "Print the mycorrhiza version and exit.")
+	flag.BoolVar(&versionFlag, "version", false, "Print version information and exit.")
 	flag.Usage = printHelp
 	flag.Parse()
 

--- a/flag.go
+++ b/flag.go
@@ -41,7 +41,8 @@ func parseCliArgs() {
 	flag.Parse()
 
 	if versionFlag {
-		fmt.Println("mycorrhiza:", version.TaggedRelease, "\tcommit:", version.CommitHash)
+		//fmt.Println("mycorrhiza:", version.TaggedRelease, "\tcommit:", version.CommitHash)
+		fmt.Println(version.FormatVersion())
 		os.Exit(0)
 	}
 

--- a/flag.go
+++ b/flag.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bouncepaw/mycorrhiza/cfg"
 	"github.com/bouncepaw/mycorrhiza/files"
 	"github.com/bouncepaw/mycorrhiza/user"
+	"github.com/bouncepaw/mycorrhiza/version"
 	"golang.org/x/term"
 )
 
@@ -31,11 +32,18 @@ func printHelp() {
 // parseCliArgs parses CLI options and sets several important global variables. Call it early.
 func parseCliArgs() {
 	var createAdminName string
+	var versionFlag bool
 
 	flag.StringVar(&cfg.ListenAddr, "listen-addr", "", "Address to listen on. For example, 127.0.0.1:1737 or /run/mycorrhiza.sock.")
 	flag.StringVar(&createAdminName, "create-admin", "", "Create a new admin. The password will be prompted in the terminal.")
+	flag.BoolVar(&versionFlag, "version", false, "Print the mycorrhiza version and exit.")
 	flag.Usage = printHelp
 	flag.Parse()
+
+	if versionFlag {
+		fmt.Println("mycorrhiza:", version.TaggedRelease, "\tcommit:", version.CommitHash)
+		os.Exit(0)
+	}
 
 	args := flag.Args()
 	if len(args) == 0 {

--- a/flag.go
+++ b/flag.go
@@ -41,7 +41,6 @@ func parseCliArgs() {
 	flag.Parse()
 
 	if versionFlag {
-		//fmt.Println("mycorrhiza:", version.TaggedRelease, "\tcommit:", version.CommitHash)
 		fmt.Println(version.FormatVersion())
 		os.Exit(0)
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+// These are set through ldflags='-X ...' in the Makefile
+var (
+	TaggedRelease string
+	CommitHash    string
+)

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,32 @@
 package version
 
-// These are set through ldflags='-X ...' in the Makefile
-var (
-	TaggedRelease string
-	CommitHash    string
+import (
+	"fmt"
+	"runtime/debug"
+	"strconv"
 )
+
+// This is set through ldflags='-X ...' in the Makefile
+var taggedRelease string = "Unknown"
+
+func FormatVersion() string {
+	var commitHash string = "Unknown"
+	var dirty string = ""
+
+	info, ok := debug.ReadBuildInfo()
+
+	if ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				commitHash = setting.Value
+			} else if setting.Key == "vcs.modified" {
+				modified, err := strconv.ParseBool(setting.Value)
+				if err == nil && modified {
+					dirty = "-dirty"
+				}
+			}
+		}
+	}
+
+	return fmt.Sprintf("Mycorrhiza Wiki %s+%s%s", taggedRelease, commitHash[:7], dirty)
+}


### PR DESCRIPTION
Closes #147

`-help` and `--help` are already provided by the flag package.

The makefile gets the most recent tagged release relative to the local HEAD (`git checkout v1.8.1~1 && git describe --tags --abbrev=0` reports v1.8.0) and the most recent commit, appending `-dirty` to the commit name if there are untracked changes

Example output:

```
./mycorrhiza -version
mycorrhiza: v1.11.0 	commit: dbaf874-dirty
```