### PR TITLE
Remove "shortcut" from link to favicon

### DIFF
--- a/viewutil/base.html
+++ b/viewutil/base.html
@@ -10,7 +10,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>{{block "title" .}}{{end}}</title>
-	<link rel="shortcut icon" href="/static/favicon.ico">
+	<link rel="icon" href="/static/favicon.ico">
 	<link rel="stylesheet" href="/static/style.css">
 	<script src="/static/shortcuts.js"></script>
 	{{range .HeadElements}}{{.}}{{end}}


### PR DESCRIPTION
> `shortcut` is not a valid `link` relation [...] It is, in fact, proprietary to Internet Explorer. Without IE, `rel="icon"` would suffice to specify a favicon.

**Source:** https://mathiasbynens.be/notes/rel-shortcut-icon