### PR TITLE
Allow unauthenticated users to view /static/style.css

### DIFF
--- a/auth/web.go
+++ b/auth/web.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bouncepaw/mycorrhiza/cfg"
 	"github.com/bouncepaw/mycorrhiza/l18n"
 	"github.com/bouncepaw/mycorrhiza/misc"
+	"github.com/bouncepaw/mycorrhiza/static"
 	"github.com/bouncepaw/mycorrhiza/user"
 	"github.com/bouncepaw/mycorrhiza/util"
 )
@@ -35,6 +36,12 @@ func InitAuth(r *mux.Router) {
 	r.HandleFunc("/login", handlerLogin)
 	r.HandleFunc("/logout", handlerLogout)
 	r.HandleFunc("/static/style.css", misc.HandlerStyle)
+	r.HandleFunc("/robots.txt", misc.HandlerRobotsTxt)
+	r.PathPrefix("/static/").
+		Handler(http.StripPrefix("/static/", http.FileServer(http.FS(static.FS))))
+	r.HandleFunc("/favicon.ico", func(w http.ResponseWriter, rq *http.Request) {
+		http.Redirect(w, rq, "/static/favicon.ico", http.StatusSeeOther)
+	})
 }
 
 func handlerUserList(w http.ResponseWriter, rq *http.Request) {

--- a/auth/web.go
+++ b/auth/web.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/bouncepaw/mycorrhiza/cfg"
 	"github.com/bouncepaw/mycorrhiza/l18n"
+	"github.com/bouncepaw/mycorrhiza/misc"
 	"github.com/bouncepaw/mycorrhiza/user"
 	"github.com/bouncepaw/mycorrhiza/util"
 )
@@ -33,6 +34,7 @@ func InitAuth(r *mux.Router) {
 	}
 	r.HandleFunc("/login", handlerLogin)
 	r.HandleFunc("/logout", handlerLogout)
+	r.HandleFunc("/static/style.css", misc.HandlerStyle)
 }
 
 func handlerUserList(w http.ResponseWriter, rq *http.Request) {

--- a/misc/handlers.go
+++ b/misc/handlers.go
@@ -22,18 +22,11 @@ import (
 )
 
 func InitHandlers(rtr *mux.Router) {
-	rtr.HandleFunc("/robots.txt", handlerRobotsTxt)
-	rtr.HandleFunc("/static/style.css", HandlerStyle)
-	rtr.PathPrefix("/static/").
-		Handler(http.StripPrefix("/static/", http.FileServer(http.FS(static.FS))))
 	rtr.HandleFunc("/list", handlerList)
 	rtr.HandleFunc("/reindex", handlerReindex)
 	rtr.HandleFunc("/update-header-links", handlerUpdateHeaderLinks)
 	rtr.HandleFunc("/random", handlerRandom)
 	rtr.HandleFunc("/about", handlerAbout)
-	rtr.HandleFunc("/favicon.ico", func(w http.ResponseWriter, rq *http.Request) {
-		http.Redirect(w, rq, "/static/favicon.ico", http.StatusSeeOther)
-	})
 	rtr.HandleFunc("/title-search/", handlerTitleSearch)
 	initViews()
 }
@@ -149,7 +142,7 @@ func HandlerStyle(w http.ResponseWriter, rq *http.Request) {
 	}
 }
 
-func handlerRobotsTxt(w http.ResponseWriter, rq *http.Request) {
+func HandlerRobotsTxt(w http.ResponseWriter, rq *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 
 	file, err := static.FS.Open("robots.txt")

--- a/misc/handlers.go
+++ b/misc/handlers.go
@@ -23,7 +23,7 @@ import (
 
 func InitHandlers(rtr *mux.Router) {
 	rtr.HandleFunc("/robots.txt", handlerRobotsTxt)
-	rtr.HandleFunc("/static/style.css", handlerStyle)
+	rtr.HandleFunc("/static/style.css", HandlerStyle)
 	rtr.PathPrefix("/static/").
 		Handler(http.StripPrefix("/static/", http.FileServer(http.FS(static.FS))))
 	rtr.HandleFunc("/list", handlerList)
@@ -134,7 +134,7 @@ func handlerAbout(w http.ResponseWriter, rq *http.Request) {
 
 var stylesheets = []string{"default.css", "custom.css"}
 
-func handlerStyle(w http.ResponseWriter, rq *http.Request) {
+func HandlerStyle(w http.ResponseWriter, rq *http.Request) {
 	w.Header().Set("Content-Type", mime.TypeByExtension(".css"))
 	for _, name := range stylesheets {
 		file, err := static.FS.Open(name)


### PR DESCRIPTION
The /lock route uses the /static/style.css file, but this file is only visible
to authenticated users, leading to an unstyled login screen