### PR TITLE
config: add `ReadOnly`

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -29,6 +29,7 @@ var (
 	URL        string
 
 	UseAuth           bool
+	ReadOnly          bool
 	AllowRegistration bool
 	RegistrationLimit uint64
 	Locked            bool
@@ -90,6 +91,7 @@ type CustomScripts struct {
 // authorization and authentication.
 type Authorization struct {
 	UseAuth           bool
+	ReadOnly          bool
 	AllowRegistration bool
 	RegistrationLimit uint64   `comment:"This field controls the maximum amount of allowed registrations."`
 	Locked            bool     `comment:"Set if users have to authorize to see anything on the wiki."`
@@ -180,6 +182,7 @@ func ReadConfigFile(path string) error {
 	}
 	URL = cfg.URL
 	UseAuth = cfg.UseAuth
+	ReadOnly = cfg.ReadOnly
 	AllowRegistration = cfg.AllowRegistration
 	RegistrationLimit = cfg.RegistrationLimit
 	Locked = cfg.Locked && cfg.UseAuth // Makes no sense to have the lock but no auth

--- a/viewutil/viewutil.go
+++ b/viewutil/viewutil.go
@@ -43,7 +43,7 @@ func Init() {
 			"inc":           func(i int) int { return i + 1 },
 		}).ParseFS(fsys, "base.html")).
 		Parse(dataText))
-	if cfg.UseAuth {
+	if cfg.UseAuth && !cfg.ReadOnly {
 		BaseEn = m(BaseEn.Parse(`
 {{define "auth"}}
 <ul class="top-bar__auth auth-links">


### PR DESCRIPTION
This option is useful for hosting a read-only instance of mycorrhiza.

when `ReadOnly = true`

- [x] Hide "Login" button
- [ ] disable editing

I don't have energy to make it really read only.