### PR TITLE
Make shortcuts work outside of English layout

### DIFF
--- a/static/shortcuts.js
+++ b/static/shortcuts.js
@@ -57,9 +57,23 @@ rrh.shortcuts = {
         if ((!event.ctrlKey && !event.metaKey && !event.altKey) &&
             event.target instanceof Node && isTextField(event.target)) return
 
-        let shortcut = keyEventToShortcut(event)
+        let possibleShortcuts = [keyEventToShortcut(event)]
+        if (event.code.startsWith('Key')) {
+            possibleShortcuts.push(keyEventToShortcut({
+                ...event,
+                key: event.code.replace(/^Key/, '').toLowerCase(),
+            }))
+        }
 
-        if (!this.active[shortcut]) {
+        let shortcut = null
+        for (let possibleShortcut of possibleShortcuts) {
+            if (possibleShortcut in this.active) {
+                shortcut = possibleShortcut
+                break
+            }
+        }
+
+        if (shortcut === null) {
             this._resetActive()
             return
         }


### PR DESCRIPTION
The keyboard event is tested two times: first time with the original key property, second time with the key property derived from the key code. This is done to support non-English shortcuts (which may be added by wiki administrators).

Fixes https://github.com/bouncepaw/mycorrhiza/issues/86