### PR TITLE
Trick safari to not recognise any "name" in the input field

### DIFF
--- a/categories/view_card.html
+++ b/categories/view_card.html
@@ -22,8 +22,8 @@
             {{if .GivenPermissionToModify}}
 				<li class="categories-card__entry categories-card__add-to-cat">
 					<form method="POST" action="/add-to-category" class="categories-card__add-form js-add-cat-form">
-						<input type="text" name="cat" id="_cat-name" class="js-add-cat-name" autocomplete="off"
-						       placeholder="{{block `placeholder` .}}Category name...{{end}}">
+						<input type="text" name="cat" id="_cat-input" class="js-add-cat-name" autocomplete="off"
+						       placeholder="{{block `placeholder` .}}Category n&zwnj;ame...{{end}}">
 						<datalist class="js-add-cat-list" id="cat-name-options"></datalist>
 						<input type="hidden" name="hypha" value="{{$hyphaName}}">
 						<input type="hidden" name="redirect-to" value="/hypha/{{$hyphaName}}">

--- a/static/default.css
+++ b/static/default.css
@@ -271,7 +271,7 @@ mark { background: rgba(130, 80, 30, 5); color: inherit; }
 	border: none;
 	background: none;
 }
-.categories-card #_cat-name {
+.categories-card #_cat-input {
 	width: 100%;
 	margin: 0;
 	padding: 0 .5rem;


### PR DESCRIPTION
Safari looks at id and placeholder in order to enable contacts autocomplete.

Fixes: #253