### PR TITLE
Don't exit when removing socket fails

### DIFF
--- a/httpd.go
+++ b/httpd.go
@@ -32,7 +32,7 @@ func serveHTTP(handler http.Handler) (err error) {
 func startUnixSocketServer(server *http.Server, socketPath string) error {
 	err := os.Remove(socketPath)
 	if err != nil {
-		return err
+		slog.Warn("Failed to clean up old socket", "err", err)
 	}
 
 	listener, err := net.Listen("unix", socketPath)


### PR DESCRIPTION
Prior to migrating to slog, errors when removing the socket were ignored.

This is fine and desirable: the most likely error condition is that the socket did not exist in the first place. Exiting on error in that case effectively prevents Mycorrhiza to be used with unix sockets.

If the removal fails for another reason, then starting the server will fail, so logging a warning is sufficient for troubleshooting.