### PR TITLE
Reorder OpenGraph search.

### DIFF
--- a/web/readers.go
+++ b/web/readers.go
@@ -258,8 +258,8 @@ func handlerHypha(w http.ResponseWriter, rq *http.Request) {
 		if err == nil {
 			ctx, _ := mycocontext.ContextFromStringInput(string(fileContentsT), mycoopts.MarkupOptions(hyphaName))
 			getOpenGraph, descVisitor, imgVisitor := tools.OpenGraphVisitors(ctx)
-			openGraph = template.HTML(getOpenGraph())
 			ast := mycomarkup.BlockTree(ctx, descVisitor, imgVisitor)
+			openGraph = template.HTML(getOpenGraph())
 			contents = template.HTML(mycomarkup.BlocksToHTML(ctx, ast))
 		}
 		switch h := h.(type) {


### PR DESCRIPTION
The previous ordering prevented the visitors from finding a description or image. I haven't detected any regressions with this change, but my testing is minimal. Perhaps somebody else knows the reason they were out of order.

It's obviously unnecessary, but here's a nice tool for verifying these sorts of things: [Lens](https://lens.rknight.me/?url=https://chrissexton.org/hypha/notes/velourcoin). My wiki has been hacked a few other ways to also emit the description and a few other things.